### PR TITLE
fix iterators so required types are defined

### DIFF
--- a/src/mesher/bindings.cpp
+++ b/src/mesher/bindings.cpp
@@ -35,11 +35,11 @@ template <typename T>
 class TypedInputIterator
 {
 public:
-    typedef std::input_iterator_tag iterator_category;
-    typedef std::ptrdiff_t difference_type;
-    typedef T value_type;
-    typedef T& reference;
-    typedef T* pointer;
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
 
     explicit TypedInputIterator(py::iterator& py_iter) :
         py_iter_(py_iter)

--- a/src/mesher/cgal_mesher.cpp
+++ b/src/mesher/cgal_mesher.cpp
@@ -83,9 +83,11 @@ template <typename T>
 class TypedInputIterator
 {
 public:
-    typedef T value_type;
-    typedef T& reference;
-    typedef T* pointer;
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
 
     explicit TypedInputIterator(py::iterator& py_iter) :
             py_iter_(py_iter)


### PR DESCRIPTION
`cgal_mesher.cpp` didn't have the full set of types, resulting in errors when compiling like:

```
  $HOME/mesher/src/mesher/cgal_mesher.cpp:235:54:   required from here
    /usr/include/c++/5/bits/stl_algobase.h:393:57: error: no type named ‘value_type’ in ‘struct std::iterator_traits<TypedInputIterator<CGAL::Point_2<CGAL::Epick> > >’
           typedef typename iterator_traits<_II>::value_type _ValueTypeI;
                                                             ^
    /usr/include/c++/5/bits/stl_algobase.h:395:64: error: no type named ‘iterator_category’ in ‘struct std::iterator_traits<TypedInputIterator<CGAL::Point_2<CGAL::Epick> > >’
           typedef typename iterator_traits<_II>::iterator_category _Category;
                                                                    ^
    /usr/include/c++/5/bits/stl_algobase.h:399:9: error: no type named ‘value_type’ in ‘struct std::iterator_traits<TypedInputIterator<CGAL::Point_2<CGAL::Epick> > >’
             && __are_same<_ValueTypeI, _ValueTypeO>::__value);
             ^
    /usr/include/c++/5/bits/stl_algobase.h:402:44: error: no type named ‘iterator_category’ in ‘struct std::iterator_traits<TypedInputIterator<CGAL::Point_2<CGAL::Epick> > >’
                            _Category>::__copy_m(__first, __last, __result);
```

I took the liberty of updating the typedef to the new `using` style.